### PR TITLE
Move template interpolation deeper into acceptance tests

### DIFF
--- a/statuscake/provider_test.go
+++ b/statuscake/provider_test.go
@@ -1,9 +1,7 @@
 package statuscake
 
 import (
-	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -12,24 +10,11 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
-var testContactGroupId int
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"statuscake": testAccProvider,
-	}
-
-	if v := os.Getenv("STATUSCAKE_TEST_CONTACT_GROUP_ID"); v == "" {
-		fmt.Println("STATUSCAKE_TEST_CONTACT_GROUP_ID must be set for acceptance tests")
-		os.Exit(1)
-	} else {
-		id, err := strconv.Atoi(v)
-		if err != nil {
-			fmt.Println("STATUSCAKE_TEST_CONTACT_GROUP_ID must be a valid int")
-			os.Exit(1)
-		}
-		testContactGroupId = id
 	}
 }
 

--- a/statuscake/resource_statuscaketest_test.go
+++ b/statuscake/resource_statuscaketest_test.go
@@ -2,6 +2,7 @@ package statuscake
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestAccStatusCake_basic(t *testing.T) {
 		CheckDestroy: testAccTestCheckDestroy(&test),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTestConfig_basic, testContactGroupId),
+				Config: interpolateTerraformTemplate(testAccTestConfig_basic),
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
 					testAccTestCheckAttributes("statuscake_test.google", &test),
@@ -38,7 +39,7 @@ func TestAccStatusCake_tcp(t *testing.T) {
 		CheckDestroy: testAccTestCheckDestroy(&test),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTestConfig_tcp, testContactGroupId),
+				Config: interpolateTerraformTemplate(testAccTestConfig_tcp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
 					testAccTestCheckAttributes("statuscake_test.google", &test),
@@ -57,7 +58,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 		CheckDestroy: testAccTestCheckDestroy(&test),
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTestConfig_basic, testContactGroupId),
+				Config: interpolateTerraformTemplate(testAccTestConfig_basic),
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
 				),
@@ -210,6 +211,19 @@ func testAccTestCheckDestroy(test *statuscake.Test) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func interpolateTerraformTemplate(template string) string {
+	testContactGroupId := 43402
+
+	if v := os.Getenv("STATUSCAKE_TEST_CONTACT_GROUP_ID"); v != "" {
+		id, err := strconv.Atoi(v)
+		if err == nil {
+			testContactGroupId = id
+		}
+	}
+
+	return fmt.Sprintf(template, testContactGroupId)
 }
 
 const testAccTestConfig_basic = `


### PR DESCRIPTION
Since it was failing `make test` on travis. Must be a better way to go about this, but I couldn't come up with a better way that defaulting the value to avoid the error when running non-acceptance tests.